### PR TITLE
fix: update test renew token and new test to generateJwt

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -81,10 +81,12 @@ describe('AuthService', () => {
         role: 'CLIENT'
       }
 
+      jest.spyOn(authService, 'generateJwt').mockResolvedValue('randomToken')
+
       const { token, user } = await authService.renewToken(newMockUser)
 
       expect(user).toEqual(newMockUser)
-      expect(typeof token).toBe('string')
+      expect(token).toBe('randomToken')
     })
   })
 


### PR DESCRIPTION
- Se integro el test para generateJwt, permitiendo obviar su correcto funcionamiento para el test del método renew token.
- Integración de mock para para el método 'generateJwt' llamado dentro de 'renewToken', ya que comprobó su correcto funcionamiento.  